### PR TITLE
feat(nginx): allow access via public and private IPs over HTTP while …

### DIFF
--- a/nginx/conf.d/odoo.conf
+++ b/nginx/conf.d/odoo.conf
@@ -10,7 +10,7 @@ upstream odoochat {
 # HTTP server - redirect to HTTPS
 server {
     listen 80;
-    server_name odoo.greenfund.rw localhost 197.243.19.174 _;
+    server_name odoo.greenfund.rw localhost _;
     
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -31,11 +31,87 @@ server {
     }
 }
 
+# HTTP server for direct IP access (no HTTPS redirect)
+server {
+    listen 80;
+    server_name 197.243.19.174 10.20.10.251;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # ACME challenge endpoint (shared)
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+        allow all;
+    }
+
+    # Common configuration
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $http_host;
+
+    # Increase proxy buffer sizes
+    proxy_buffering on;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
+
+    # Increase timeouts
+    proxy_connect_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
+    # Client configuration
+    client_max_body_size 200M;
+    client_body_timeout 60s;
+    client_header_timeout 60s;
+
+    # Handle longpolling requests
+    location /longpolling {
+        proxy_pass http://odoochat;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_redirect off;
+    }
+
+    # Static files cache
+    location ~* /web/static/ {
+        proxy_cache_valid 200 60m;
+        proxy_buffering on;
+        expires 864000;
+        proxy_pass http://odoo;
+    }
+
+    # Main Odoo location
+    location / {
+        proxy_pass http://odoo;
+        proxy_redirect off;
+    }
+
+    # Health check endpoint
+    location /nginx-health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}
+
 # HTTPS server
 server {
     listen 443 ssl;
     http2 on;
-    server_name odoo.greenfund.rw localhost 197.243.19.174 _;
+    server_name odoo.greenfund.rw localhost;
     
     # SSL configuration
     ssl_certificate /etc/letsencrypt/live/odoo.greenfund.rw/fullchain.pem;


### PR DESCRIPTION
…keeping HTTPS for domain

- Add dedicated HTTP server block for 197.243.19.174 and 10.20.10.251 without HTTPS redirect
- Keep domain-only HTTPS () with Let’s Encrypt certs
- Serve ACME challenges on HTTP for issuance/renewal