### PR TITLE
fix(nginx): set IP HTTP server as default_server on port 80

### DIFF
--- a/nginx/conf.d/odoo.conf
+++ b/nginx/conf.d/odoo.conf
@@ -33,7 +33,7 @@ server {
 
 # HTTP server for direct IP access (no HTTPS redirect)
 server {
-    listen 80;
+    listen 80 default_server;
     server_name 197.243.19.174 10.20.10.251;
 
     # Security headers


### PR DESCRIPTION
- Route unmatched Host headers to IP-access server block
- Ensure direct access via 197.243.19.174 and 10.20.10.251 works
- Keep domain HTTPS behavior and ACME challenge handling unchanged